### PR TITLE
print dirname in console

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,9 @@ var map = require('map-stream');
 var stylish = require(require('jshint-stylish'));
 
 function toJshint (errors) {
-	return errors.map(function (error) {
+	return file.jscs.errors.map(function (error) {
 		return {
-			file: error.filename,
+			file: file.base + error.filename,
 			error: {
 				character: error.column,
 				code: error.rule,
@@ -18,7 +18,7 @@ function toJshint (errors) {
 module.exports = function () {
 	return map(function (file, cb) {
 		if (file.jscs && file.jscs.errorCount) {
-			stylish.reporter(toJshint(file.jscs.errors));
+			stylish.reporter(toJshint(file));
 		}
 		cb(null, file);
 	});


### PR DESCRIPTION
hi, @gonsfx when I'm used gulp-jscs, I'm so depressed, 
because, it can't print errors and warnings like `gulp-jshint`. 

luckily, I found `gulp-jscs-stylish`, It's kindly, But there is a little small flaws.
she don't print the `dirname` with file name.

I think it's ambiguity, when 
dir/
  a/index.js
  b/index.js

so, I  improved  the `index.js`, she will print `dirname + filename` like `gulp-jshint` did.
i think it's good. tks.
