### PR TITLE
Added the possibility to use jshint reporter without running jshint

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,15 +35,7 @@ module.exports = tapJscs(function (file) {
 });
 
 module.exports.combineWithHintResults = tapJscs(function (file) {
-	file.jshint.success = false;
-	file.jshint.results = (file.jshint.results || []).concat(toJshint(file));
-	file.jshint.results.sort(byErrorLine);
-});
-
-module.exports.createHintResults = tapJscs(function (file) {
-	if (!file.jshint) {
-		file.jshint = {};
-	}
+	file.jshint = file.jshint || {};
 	file.jshint.success = false;
 	file.jshint.results = (file.jshint.results || []).concat(toJshint(file));
 	file.jshint.results.sort(byErrorLine);

--- a/index.js
+++ b/index.js
@@ -39,3 +39,12 @@ module.exports.combineWithHintResults = tapJscs(function (file) {
 	file.jshint.results = (file.jshint.results || []).concat(toJshint(file));
 	file.jshint.results.sort(byErrorLine);
 });
+
+module.exports.createHintResults = tapJscs(function (file) {
+	if (!file.jshint) {
+		file.jshint = {};
+	}
+	file.jshint.success = false;
+	file.jshint.results = (file.jshint.results || []).concat(toJshint(file));
+	file.jshint.results.sort(byErrorLine);
+});

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ var stylish = require('gulp-jscs-stylish');
 
 gulp.task('default', function () {
 	gulp.src([ 'file.js' ])
-		.pipe(jshint())                           // hint
+		.pipe(jshint())                           // hint (optional)
 		.pipe(jscs())                             // enforce style guide
 		.on('error', noop)                        // don't stop on error
 		.pipe(stylish.combineWithHintResults())   // combine with jshint results
@@ -49,24 +49,7 @@ gulp.task('default', function () {
 		                                          // and style guide errors
 });
 ````
-
-## Use JSHint reporter without running JSHint
-
-```js
-var jscs = require('gulp-jscs');
-var jshint = require('gulp-jshint');
-var noop = function () {};
-var stylish = require('gulp-jscs-stylish');
-
-gulp.task('default', function () {
-	gulp.src([ 'file.js' ])
-		.pipe(jscs())                             // enforce style guide
-		.on('error', noop)                        // don't stop on error
-		.pipe(stylish.createHintResults())   // combine with jshint results
-		.pipe(jshint.reporter('jshint-stylish')); // use any jshint reporter to log hint
-		                                          // and style guide errors
-});
-````
+using `.pipe(jshint())` is optional. you may very well use the reporter without running jshint
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,24 @@ gulp.task('default', function () {
 });
 ````
 
+## Use JSHint reporter without running JSHint
+
+```js
+var jscs = require('gulp-jscs');
+var jshint = require('gulp-jshint');
+var noop = function () {};
+var stylish = require('gulp-jscs-stylish');
+
+gulp.task('default', function () {
+	gulp.src([ 'file.js' ])
+		.pipe(jscs())                             // enforce style guide
+		.on('error', noop)                        // don't stop on error
+		.pipe(stylish.createHintResults())   // combine with jshint results
+		.pipe(jshint.reporter('jshint-stylish')); // use any jshint reporter to log hint
+		                                          // and style guide errors
+});
+````
+
 ## License
 
 MIT © [Christoph Werner](http://twitter.com/gonsfx)


### PR DESCRIPTION
I love this little plugin, but found something missing for our use case.

I have added a little method for the case you want to run jscs without running jshint but still want to use jshint reporters.
