### PR TITLE
Fixing new version gulp-jscs

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function tapJscs (action) {
 }
 
 function toJshint (file) {
-	return file.jscs.errors.map(function (error) {
+	return file.jscs.errors._errorList.map(function (error) {
 		return {
 			file: file.base + error.filename,
 			error: {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "gulp-tap": "^0.1.3",
-    "jshint-stylish": "^1.0.0"
+    "jshint-stylish": "^2.0.0"
   },
   "devDependencies": {
   }

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,6 @@ var stylish = require('gulp-jscs-stylish');
 gulp.task('default', function () {
 	gulp.src([ 'file.js' ])
 		.pipe(jscs())      // enforce style guide
-		.on('error', noop) // don't stop on error
 		.pipe(stylish());  // log style errors
 });
 ```
@@ -43,7 +42,6 @@ gulp.task('default', function () {
 	gulp.src([ 'file.js' ])
 		.pipe(jshint())                           // hint (optional)
 		.pipe(jscs())                             // enforce style guide
-		.on('error', noop)                        // don't stop on error
 		.pipe(stylish.combineWithHintResults())   // combine with jshint results
 		.pipe(jshint.reporter('jshint-stylish')); // use any jshint reporter to log hint
 		                                          // and style guide errors


### PR DESCRIPTION
Now gulp-jscs need call explicit [report function](https://github.com/jscs-dev/gulp-jscs#reporting) (and no need call `.on('error', noop)` ) and file.jscs.errors return all object error, not only errors list
