### PR TITLE
This fixes gonsfx/gulp-jscs-stylish#11

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function toJshint (file) {
 	// map errors to jshint format
 	return errorList.map(function (error) {
 		return {
-			file: file.base + error.filename,
+			file: error.filename,
 			error: {
 				character: error.column,
 				code: 'W ' + error.rule,


### PR DESCRIPTION
It seems the error.filename already contains the full path to the filename, no need to add an additional path.
