### PR TITLE
Fix gonsfx/gulp-jscs-stylish#14

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var tap = require('gulp-tap');
 var stylish = typeof require('jshint-stylish') === 'string' ? require(require('jshint-stylish')) : require('jshint-stylish');
 
@@ -19,11 +20,12 @@ function tapJscs (action) {
 function toJshint (file) {
 	// fetch error list
 	var errorList = file.jscs.errors._errorList || file.jscs.errors;
+	var filePath = path.relative(process.cwd(), file.path);
 
 	// map errors to jshint format
 	return errorList.map(function (error) {
 		return {
-			file: error.filename,
+			file: filePath,
 			error: {
 				character: error.column,
 				code: 'W ' + error.rule,


### PR DESCRIPTION
This fixes #14 

I went through the commit logs to reconstruct the history of the problem, before trying to fix it. Here's what I came up with:
1. At first only the name of a file was reported using [`error.filename`](https://github.com/gonsfx/gulp-jscs-stylish/blob/21eed8703c0896c92fdf11fc0b774ea5521e2f3c/index.js#L7).
2. This proved ambiguous with files like `a/index.js` and `b/index.js` which led to fix #1: prepending `file.base` to `error.filename`.
3. However the value of `error.filename` was changed to an absolute path in [this gulp-jscs commit](https://github.com/jscs-dev/gulp-jscs/commit/0fde1cc0ef857b939a97f21440a4edf1dc3511a3). Suddenly there were duplicate parts in file paths, see #11. So it was back to `error.filename`.
4. Which brings us to issue #14.

The fix I'm proposing shouldn't reintroduce any of the previous issues and is a direct analogue of the way [gulp-jshint constructs CWD relative file paths](https://github.com/spalger/gulp-jshint/blob/69c9c17e65421e4ebd7e5a01dc48e0c4d1676b45/src/lint.js#L44).

Since this plugin is predicated on delegating the actual reporting to jshint-stylish, producing the exact same paths that gulp-jshint produces and that are expected by jshint-stylish seems to be the best approach.

Here's the output created by my fix using the [example repo I set up](https://github.com/svenschoenung/issue-gulp-jscs-stylish-absolute-paths):

![fixed-screenshot](https://cloud.githubusercontent.com/assets/10583730/14537804/d9b44b14-0278-11e6-8b24-a6e5cb384b33.png)
